### PR TITLE
Improve active code tab color

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -875,7 +875,8 @@ section#editor ul#files > li {
 }
 
 section#editor ul#files > li.active {
-  background-color: #232a25;
+  background-color: #e9ecef;
+  color: #111;
 }
 
 section#editor ul#files > li.active input {


### PR DESCRIPTION
## Current:

<img width="620" height="376" alt="2025-11-08_11-55" src="https://github.com/user-attachments/assets/f47d5fdc-b61c-4bbf-a56a-b37b82ab374c" />

## My suggestion:

<img width="618" height="372" alt="2025-11-08_11-54" src="https://github.com/user-attachments/assets/0dcbfce6-cc1f-49e0-a6b7-9538bda2d1c0" />

## Related

#107


